### PR TITLE
Joomla 6 compatibility: Fix deprecated CMS Filesystem class by using framework instead

### DIFF
--- a/src/src/Helper/RfVideoHelper.php
+++ b/src/src/Helper/RfVideoHelper.php
@@ -9,9 +9,9 @@
 
 namespace RichardFath\Module\RfVideo\Site\Helper;
 
-use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 


### PR DESCRIPTION
This pull request (PR) fixes the PHP error `Class "Joomla\CMS\Filesystem\Path" not found` which you get on Joomla 6 when the "Behaviour - Backward Compatibility 6" plugin is disabled by using the `Joomla\Filesystem\Path` class from the Joomla Framework instead.